### PR TITLE
Created a separate option for the capacity check and added performance data

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ optional arguments:
 *   -p api password       **(Required)** Your API username
 *   -v                    **(Optional)** List full output (not only alerts), default: off
 *   -f capacity           **(Not required)** Raise alert if limit is hit: 80,90 as percent for WARNING,CRITICAL
-*   -c all mem psu fan disk ports volume volgroup alert [all mem psu fan disk ports volume volgroup alert ...] **(Required)** List of checks, choose all, one or few.
+*   -c all mem psu fan disk ports volume volgroup alert capacity [all mem psu fan disk ports volume volgroup alert ...] **(Required)** List of checks, choose all, one or few.
 
             Short description of checks option:
             all - show all checks
@@ -55,4 +55,5 @@ optional arguments:
             volume - show volumes, checks if volume is operating normally
             volgroup - check volume groups, checks if it's protectable and write order consistent
             alert - show Critical and Major alerts (raise alert if there is no acknowledged)
+            capacity - check total capacity
 

--- a/check_powerstore_api.py
+++ b/check_powerstore_api.py
@@ -172,6 +172,7 @@ if __name__ == "__main__":
             volume - show volumes, checks if volume is operating normally
             volgroup - check volume groups, checks if it's protectable and write order consistent
             alert - show Critical and Major alerts (raise alert if there is no acknowledged)
+            capacity - check total capacity
                    """,
             formatter_class=RawTextHelpFormatter,
             usage=SUPPRESS)
@@ -185,7 +186,7 @@ if __name__ == "__main__":
                             required=False, default="0,0")
         parser.add_argument("-c", metavar="all mem psu fan disk ports volume volgroup alert",
                             help="(Required) List of checks, choose all, one or few.",
-                            nargs="+", choices=["all", "mem", "psu", "fan", "disk", "ports", "volume", "volgroup", "alert"], required=True)
+                            nargs="+", choices=["all", "mem", "psu", "fan", "disk", "ports", "volume", "volgroup", "alert","capacity"], required=True)
         args = parser.parse_args()
     except SystemExit as error:
         if error.code == 2:
@@ -225,14 +226,15 @@ if __name__ == "__main__":
         check_alerts(hostname)
     if "ports" in checks and not "all" in checks:
         check_ports(hostname)
+    if "capacity" in checks and not "all" in checks:
+        check_capacity(hostname, free_limit)
     if "all" in checks:
         check_volumes(hostname)
         check_alerts(hostname)
         check_volumegroup(hostname)
         check_ports(hostname)
-
-    if free_limit != 0:
         check_capacity(hostname, free_limit)
+
     if exit_code == 0:
         if verbose:
             print("OK: No problem detected.\n" + output)

--- a/check_powerstore_api.py
+++ b/check_powerstore_api.py
@@ -183,7 +183,7 @@ if __name__ == "__main__":
                             default=False, action="store_true")
         parser.add_argument("-f", metavar="capacity",
                             help="(Not required) Raise alert if limit is hit: 80,90 as percent for WARNING,CRITICAL",
-                            required=False, default="0,0")
+                            required=False, default="80,90")
         parser.add_argument("-c", metavar="all mem psu fan disk ports volume volgroup alert",
                             help="(Required) List of checks, choose all, one or few.",
                             nargs="+", choices=["all", "mem", "psu", "fan", "disk", "ports", "volume", "volgroup", "alert","capacity"], required=True)

--- a/check_powerstore_api.py
+++ b/check_powerstore_api.py
@@ -112,7 +112,7 @@ def check_capacity(hostname, limit):
             output += " (!!)"
         output += "\n-----------------------------"
     if perf:
-        output += f'| USED={str(round(used_space, 2))}[TB];{limit[0]};{limit[1]};0;{str(round(total_space))}'
+        output += f'| USED={str(round(used_space, 2))}TB;{limit[0]};{limit[1]};0;{str(round(total_space))}'
 
 
 def check_volumegroup(hostname):

--- a/check_powerstore_api.py
+++ b/check_powerstore_api.py
@@ -106,11 +106,13 @@ def check_capacity(hostname, limit):
         sys.exit(3)
 
     if verbose or raise_alert:
-        output += "\nCapacity - FREE:" + str(free) + "TB (" + str(free_procent) + "%), USED: " + str(
-            round(used_space, 2)) + "TB, TOTAL: " + str(round(total_space)) + "TB"
+        output += "\nCapacity - FREE:" + str(round(free, 2)) + "TB (" + str(free_procent) + "%), USED: " + str(
+             round(used_space, 2)) + "TB, TOTAL: " + str(round(total_space)) + "TB"
         if raise_alert:
             output += " (!!)"
         output += "\n-----------------------------"
+    if perf:
+        output += f'| USED={str(round(used_space, 2))}[TB];{limit[0]};{limit[1]};0;{str(round(total_space))}'
 
 
 def check_volumegroup(hostname):
@@ -181,6 +183,7 @@ if __name__ == "__main__":
         parser.add_argument("-p", metavar="api password", help="(Required) Your API username", required=True)
         parser.add_argument('-v', help="(Optional) List full output (not only alerts), default: off",
                             default=False, action="store_true")
+        parser.add_argument('-P', help="Enable performance data", default=False, action="store_true")
         parser.add_argument("-f", metavar="capacity",
                             help="(Not required) Raise alert if limit is hit: 80,90 as percent for WARNING,CRITICAL",
                             required=False, default="80,90")
@@ -203,6 +206,7 @@ if __name__ == "__main__":
     free_limit = args.f.split(",")
     verbose = args.v
     checks = args.c
+    perf = args.P
 
     if "all" in checks:
         hardware_checks = ["DIMM", "Power_Supply", "Fan", "Drive"]


### PR DESCRIPTION
The capacity check will now no longer be underneath each output. It now has its own option in `-c` and I added performance data in the output with `-P`

I also edited the default `-f` value to 80,90. because I think 0,0 will always give an error.
```python
check_powerstore_api.py -H 10.1.35.50 -u <username> -p <password> -c capacity -v -f 80,90 -P
OK: No problem detected.

Capacity - FREE:5.19TB (71.8%), USED: 13.22TB, TOTAL: 18TB
-----------------------------| USED=13.22[TB];80;90;0;18```